### PR TITLE
added basic revive functionality. doesn't detect dead items automatically yet though.

### DIFF
--- a/foo_bestversion/BestVersion.cpp
+++ b/foo_bestversion/BestVersion.cpp
@@ -111,6 +111,87 @@ bool doesTrackHaveSimilarTitle(const std::string& title, const metadb_handle_ptr
 	return false;
 }
 
+bool doesTrackHaveExactTitle(const std::string& title, const metadb_handle_ptr& track)
+{
+	// todo: ignore slight differences, e.g. in punctuation
+	service_ptr_t<metadb_info_container> outInfo;
+	if (!track->get_async_info_ref(outInfo))
+	{
+		return false;
+	}
+
+	const file_info& fileInfo = outInfo->info();
+
+	if (!fileInfo.meta_exists("title"))
+	{
+		return false;
+	}
+
+
+	const std::string fileTitle = fileInfo.meta_get("title", 0);
+
+	if (stricmp_utf8(fileTitle.c_str(), title.c_str()) == 0)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+bool doesTrackHaveExactAlbum(const std::string& album, const metadb_handle_ptr& track)
+{
+	// todo: ignore slight differences, e.g. in punctuation
+	service_ptr_t<metadb_info_container> outInfo;
+	if (!track->get_async_info_ref(outInfo))
+	{
+		return false;
+	}
+
+	const file_info& fileInfo = outInfo->info();
+
+	if (!fileInfo.meta_exists("album"))
+	{
+		return false;
+	}
+
+
+	const std::string fileAlbum = fileInfo.meta_get("album", 0);
+
+	if (stricmp_utf8(fileAlbum.c_str(), album.c_str()) == 0)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+bool doesTrackHaveExactTrackNumber(const std::string& tracknumber, const metadb_handle_ptr& track)
+{
+	// todo: ignore slight differences, e.g. in punctuation
+	service_ptr_t<metadb_info_container> outInfo;
+	if (!track->get_async_info_ref(outInfo))
+	{
+		return false;
+	}
+
+	const file_info& fileInfo = outInfo->info();
+
+	if (!fileInfo.meta_exists("tracknumber"))
+	{
+		return false;
+	}
+
+
+	const std::string fileAlbum = fileInfo.meta_get("tracknumber", 0);
+
+	if (stricmp_utf8(fileAlbum.c_str(), tracknumber.c_str()) == 0)
+	{
+		return true;
+	}
+
+	return false;
+}
+
 //------------------------------------------------------------------------------
 
 void filterTracksByArtist(const std::string& artist, pfc::list_base_t<metadb_handle_ptr>& tracks)
@@ -142,6 +223,45 @@ void filterTracksByCloseTitle(const std::string& title, pfc::list_base_t<metadb_
 }
 
 //------------------------------------------------------------------------------
+
+void filterTracksByExactTitle(const std::string& title, pfc::list_base_t<metadb_handle_ptr>& tracks)
+{
+	const t_size n = tracks.get_count();
+	bit_array_bittable deleteMask(n);
+
+	for (t_size i = 0; i < n; i++)
+	{
+		deleteMask.set(i, !doesTrackHaveExactTitle(title, tracks[i]));
+	}
+
+	tracks.remove_mask(deleteMask);
+}
+
+void filterTracksByAlbum(const std::string& album, pfc::list_base_t<metadb_handle_ptr>& tracks)
+{
+	const t_size n = tracks.get_count();
+	bit_array_bittable deleteMask(n);
+
+	for (t_size i = 0; i < n; i++)
+	{
+		deleteMask.set(i, !doesTrackHaveExactAlbum(album, tracks[i]));
+	}
+
+	tracks.remove_mask(deleteMask);
+}
+
+void filterTracksByTrackNumber(const std::string& tracknumber, pfc::list_base_t<metadb_handle_ptr>& tracks)
+{
+	const t_size n = tracks.get_count();
+	bit_array_bittable deleteMask(n);
+
+	for (t_size i = 0; i < n; i++)
+	{
+		deleteMask.set(i, !doesTrackHaveExactTrackNumber(tracknumber, tracks[i]));
+	}
+
+	tracks.remove_mask(deleteMask);
+}
 
 bool fileTitlesMatchExcludingBracketsOnLhs(const std::string& lhs, const std::string& rhs)
 {

--- a/foo_bestversion/BestVersion.cpp
+++ b/foo_bestversion/BestVersion.cpp
@@ -377,6 +377,52 @@ metadb_handle_ptr getBestTrackByTitle(const std::string& title, const pfc::list_
 	return bestTrack;
 }
 
+void findAllDeadItemsInAllPlaylists()
+{
+	static_api_ptr_t<playlist_manager> pm;
+	t_size playlist_count = pm->get_playlist_count();
+	pfc::list_t<metadb_handle_ptr> dead_tracks;
+	std::string output_playlist_name = "[foo_bestversion]DEAD ITEMS";
+	for (t_size playlist_index = 0; playlist_index < playlist_count; playlist_index++)
+	{
+		findDeadItemsInPlaylist(playlist_index, dead_tracks);
+	}
+	t_size output_playlist = pm->find_playlist(output_playlist_name.c_str(), pfc_infinite);
+
+	if (output_playlist != pfc_infinite)
+	{
+		pm->playlist_undo_backup(output_playlist);
+		pm->playlist_clear(output_playlist);
+	}
+	else
+	{
+		output_playlist = pm->create_playlist(
+			output_playlist_name.c_str(),
+			pfc_infinite,
+			pfc_infinite
+		);
+	}
+
+	pm->playlist_add_items(output_playlist, dead_tracks, bit_array_true());
+	pm->set_active_playlist(output_playlist);
+	pm->set_playing_playlist(output_playlist);
+}
+
+void findDeadItemsInPlaylist(t_size playlist, pfc::list_base_t<metadb_handle_ptr>& track_list) {
+	static_api_ptr_t<playlist_manager> pm;
+	pfc::list_t<metadb_handle_ptr> all_tracks;
+	pm->playlist_get_all_items(playlist, all_tracks);
+	abort_callback_dummy abort;
+	for (t_size index = 0; index < all_tracks.get_count(); index++)
+	{
+		if (!filesystem::g_exists(all_tracks[index]->get_path(), abort)) 
+		{
+			track_list.add_item(all_tracks[index]);
+		}
+	}
+
+}
+
 //------------------------------------------------------------------------------
 
 } // namespace bestversion

--- a/foo_bestversion/BestVersion.h
+++ b/foo_bestversion/BestVersion.h
@@ -11,10 +11,16 @@ std::string getMainArtist(metadb_handle_list_cref tracks);
 bool isTrackByArtist(const std::string& artist, const metadb_handle_ptr& track);
 
 bool doesTrackHaveSimilarTitle(const std::string& title, const metadb_handle_ptr& track);
+bool doesTrackHaveExactTitle(const std::string& title, const metadb_handle_ptr& track);
+bool doesTrackHaveExactAlbum(const std::string& album, const metadb_handle_ptr& track);
+bool doesTrackHaveExactTrackNumber(const std::string& tracknumber, const metadb_handle_ptr& track);
 
 void filterTracksByArtist(const std::string& artist, pfc::list_base_t<metadb_handle_ptr>& tracks);
+void filterTracksByAlbum(const std::string& album, pfc::list_base_t<metadb_handle_ptr>& tracks);
+void filterTracksByTrackNumber(const std::string& tracknumber, pfc::list_base_t<metadb_handle_ptr>& tracks);
 
 void filterTracksByCloseTitle(const std::string& title, pfc::list_base_t<metadb_handle_ptr>& tracks);
+void filterTracksByExactTitle(const std::string& title, pfc::list_base_t<metadb_handle_ptr>& tracks);
 
 bool fileTitlesMatchExcludingBracketsOnLhs(const std::string& lhs, const std::string& rhs);
 

--- a/foo_bestversion/BestVersion.h
+++ b/foo_bestversion/BestVersion.h
@@ -10,17 +10,13 @@ std::string getMainArtist(metadb_handle_list_cref tracks);
 
 bool isTrackByArtist(const std::string& artist, const metadb_handle_ptr& track);
 
-bool doesTrackHaveSimilarTitle(const std::string& title, const metadb_handle_ptr& track);
-bool doesTrackHaveExactTitle(const std::string& title, const metadb_handle_ptr& track);
-bool doesTrackHaveExactAlbum(const std::string& album, const metadb_handle_ptr& track);
-bool doesTrackHaveExactTrackNumber(const std::string& tracknumber, const metadb_handle_ptr& track);
+bool doesTrackHaveExactTagFieldValue(const std::string& field_name, const std::string& field_value, const metadb_handle_ptr& track);
+bool doesTrackHaveSimilarTitle(const std::string& title, const metadb_handle_ptr& track, bool exact=false);
 
+void filterTracksByTagField(const std::string& field_name, const std::string& field_value, pfc::list_base_t<metadb_handle_ptr>& tracks);
 void filterTracksByArtist(const std::string& artist, pfc::list_base_t<metadb_handle_ptr>& tracks);
-void filterTracksByAlbum(const std::string& album, pfc::list_base_t<metadb_handle_ptr>& tracks);
-void filterTracksByTrackNumber(const std::string& tracknumber, pfc::list_base_t<metadb_handle_ptr>& tracks);
 
-void filterTracksByCloseTitle(const std::string& title, pfc::list_base_t<metadb_handle_ptr>& tracks);
-void filterTracksByExactTitle(const std::string& title, pfc::list_base_t<metadb_handle_ptr>& tracks);
+void filterTracksByCloseTitle(const std::string& title, pfc::list_base_t<metadb_handle_ptr>& tracks, bool exact=false);
 
 bool fileTitlesMatchExcludingBracketsOnLhs(const std::string& lhs, const std::string& rhs);
 

--- a/foo_bestversion/BestVersion.h
+++ b/foo_bestversion/BestVersion.h
@@ -25,4 +25,7 @@ float calculateTrackRating(const std::string& title, const metadb_handle_ptr& tr
 // all tracks will be analysed; try to cut the size of the list down before calling.
 metadb_handle_ptr getBestTrackByTitle(const std::string& title, const pfc::list_base_t<metadb_handle_ptr>& tracks);
 
+void findAllDeadItemsInAllPlaylists();
+void findDeadItemsInPlaylist(t_size playlist, pfc::list_base_t<metadb_handle_ptr>& track_list);
+
 } // namespace bestversion

--- a/foo_bestversion/ContextMenu.cpp
+++ b/foo_bestversion/ContextMenu.cpp
@@ -624,9 +624,9 @@ void replaceWithLibraryVersion(const metadb_handle_ptr& track)
 	lm->get_all_items(library);
 
 	filterTracksByArtist(artist, library);
-	filterTracksByExactTitle(title, library);
-	filterTracksByAlbum(album, library);
-	filterTracksByTrackNumber(track_n, library);
+	filterTracksByCloseTitle(title, library, true);
+	filterTracksByTagField("album", album, library);
+	filterTracksByTagField("tracknumber", track_n, library);
 
 
 	const metadb_handle_ptr bestVersionOfTrack = getBestTrackByTitle(title, library);

--- a/foo_bestversion/ContextMenu.cpp
+++ b/foo_bestversion/ContextMenu.cpp
@@ -24,7 +24,7 @@ const contextmenu_group_popup_factory bestVersionContextMenuGroupFactory(bestVer
 
 void generateArtistPlaylist(const pfc::list_base_const_t<metadb_handle_ptr>& tracks);
 void replaceWithBestVersion(const pfc::list_base_const_t<metadb_handle_ptr>& tracks);
-void replaceWithLibraryVersion(const pfc::list_base_const_t<metadb_handle_ptr>& tracks);
+void replaceWithLibraryVersion(const pfc::list_base_const_t<metadb_handle_ptr>& tracks, bool acrossAllPlaylists=false);
 
 //------------------------------------------------------------------------------
 
@@ -209,6 +209,7 @@ public:
 		{
 			ReplaceWithBestVersion = 0,
 			ReplaceWithLibraryVersion,
+			ReplaceWIthLibraryVersionAcrossAllPlaylists,
 			MAX
 		};
 	};
@@ -245,6 +246,12 @@ public:
 				break;
 			}
 
+			case Items::ReplaceWIthLibraryVersionAcrossAllPlaylists:
+			{
+				out = "Replace with same track in the library in all playlists";
+				break;
+			}
+
 			default:
 			{
 				uBugCheck();
@@ -269,8 +276,13 @@ public:
 
 			case Items::ReplaceWithLibraryVersion:
 			{
-				//replaceWithBestVersion(tracks);
 				replaceWithLibraryVersion(tracks);
+				break;
+			}
+
+			case Items::ReplaceWIthLibraryVersionAcrossAllPlaylists:
+			{
+				replaceWithLibraryVersion(tracks, true);
 				break;
 			}
 
@@ -324,6 +336,10 @@ public:
 		// {B9144A8F-8839-49D7-B2DA-C9CE9ED7517E}
 		static const GUID ReplaceWithLibraryVersionGUID = { 0xb9144a8f, 0x8839, 0x49d7,{ 0xb2, 0xda, 0xc9, 0xce, 0x9e, 0xd7, 0x51, 0x7e } };
 
+		// {1B059698-B4EC-4E1F-962A-6C749AC14985}
+		static const GUID ReplaceWithLibraryVersionAcrossAllPlaylistsGUID =	{ 0x1b059698, 0xb4ec, 0x4e1f,{ 0x96, 0x2a, 0x6c, 0x74, 0x9a, 0xc1, 0x49, 0x85 } };
+
+
 
 		switch(index)
 		{
@@ -335,6 +351,11 @@ public:
 			case Items::ReplaceWithLibraryVersion:
 			{
 				return ReplaceWithLibraryVersionGUID;
+			}
+
+			case Items::ReplaceWIthLibraryVersionAcrossAllPlaylists:
+			{
+				return ReplaceWithLibraryVersionAcrossAllPlaylistsGUID;
 			}
 
 			default:
@@ -361,6 +382,12 @@ public:
 			case Items::ReplaceWithLibraryVersion:
 			{
 				out = "Replace a track in a playlist with the same file from the library, if it exists.";
+				return true;
+			}
+
+			case Items::ReplaceWIthLibraryVersionAcrossAllPlaylists:
+			{
+				out = "Replace a track in a playlist with the same file from the library, if it exists, across all playlists.";
 				return true;
 			}
 
@@ -569,7 +596,7 @@ void replaceWithBestVersion(const pfc::list_base_const_t<metadb_handle_ptr>& tra
 
 //------------------------------------------------------------------------------
 
-void replaceWithLibraryVersion(const metadb_handle_ptr& track)
+void replaceWithLibraryVersion(const metadb_handle_ptr& track, bool acrossAllPlaylists)
 {
 	service_ptr_t<metadb_info_container> outInfo;
 	if (!track->get_async_info_ref(outInfo))
@@ -635,17 +662,21 @@ void replaceWithLibraryVersion(const metadb_handle_ptr& track)
 	{
 		console::printf("Couldn't find a library version of %s", title.c_str());
 	}
-	else
+	else if (!acrossAllPlaylists)
 	{
 		replaceTrackInActivePlaylist(track, bestVersionOfTrack);
 	}
+	else
+	{
+		replaceTrackInAllPlaylists(track, bestVersionOfTrack);
+	}
 }
 
-void replaceWithLibraryVersion(const pfc::list_base_const_t<metadb_handle_ptr>& tracks)
+void replaceWithLibraryVersion(const pfc::list_base_const_t<metadb_handle_ptr>& tracks, bool acrossAllPlaylists)
 {
 	for (t_size index = 0; index < tracks.get_count(); ++index)
 	{
-		replaceWithLibraryVersion(tracks[index]);
+		replaceWithLibraryVersion(tracks[index], acrossAllPlaylists);
 	}
 }
 

--- a/foo_bestversion/MainMenu.cpp
+++ b/foo_bestversion/MainMenu.cpp
@@ -1,0 +1,75 @@
+//#include "ContextMenu.h"
+
+#include "FoobarSDKWrapper.h"
+
+#include "BestVersion.h"
+//#include "LastFm.h"
+//#include "PlaylistGenerator.h"
+
+//#include <map>
+
+using namespace bestversion;
+
+// {EC9EB231-1C89-47BA-AF87-811D80096B86}
+static const GUID g_mainmenu_group_id = { 0xec9eb231, 0x1c89, 0x47ba,{ 0xaf, 0x87, 0x81, 0x1d, 0x80, 0x9, 0x6b, 0x86 } };
+
+
+static mainmenu_group_popup_factory g_mainmenu_group(g_mainmenu_group_id, mainmenu_groups::edit, mainmenu_commands::sort_priority_dontcare, "Best Version");
+
+
+class mainmenu_edit_commands : public mainmenu_commands {
+public:
+	enum {
+		cmd_test = 0,
+		cmd_findalldead,
+		cmd_total
+	};
+	t_uint32 get_command_count() {
+		return cmd_total;
+	}
+	GUID get_command(t_uint32 p_index) {
+		// {BEEA7056-79F6-45AD-BCC0-EEB5AD934656}
+		static const GUID guid_test = { 0xbeea7056, 0x79f6, 0x45ad,{ 0xbc, 0xc0, 0xee, 0xb5, 0xad, 0x93, 0x46, 0x56 } };
+
+		// {E45AED1B-2A80-4A94-BAE0-0FD3C55BFAED}
+		static const GUID guid_findalldead = { 0xe45aed1b, 0x2a80, 0x4a94,{ 0xba, 0xe0, 0xf, 0xd3, 0xc5, 0x5b, 0xfa, 0xed } };
+
+		switch (p_index) {
+		case cmd_test: return guid_test;
+		case cmd_findalldead: return guid_findalldead;
+		default: uBugCheck(); // should never happen unless somebody called us with invalid parameters - bail
+		}
+	}
+	void get_name(t_uint32 p_index, pfc::string_base & p_out) {
+		switch (p_index) {
+		case cmd_test: p_out = "Test command"; break;
+		case cmd_findalldead: p_out = "Find dead items across all playlists"; break;
+		default: uBugCheck(); // should never happen unless somebody called us with invalid parameters - bail
+		}
+	}
+	bool get_description(t_uint32 p_index, pfc::string_base & p_out) {
+		switch (p_index) {
+		case cmd_test: p_out = "This is a sample menu command."; return true;
+		case cmd_findalldead: p_out = "Finds all dead items in all playlists and dumps them into a new playlist. Doesn't remove duplicates."; return true;
+		default: uBugCheck(); // should never happen unless somebody called us with invalid parameters - bail
+		}
+	}
+	GUID get_parent() {
+		return g_mainmenu_group_id;
+	}
+	void execute(t_uint32 p_index, service_ptr_t<service_base> p_callback) {
+		switch (p_index) {
+		case cmd_test:
+			popup_message::g_show("This is a sample menu command.", "Blah");
+			break;
+		case cmd_findalldead:
+			//popup_message::g_show("Here was a function call to RunPlaybackStateDemo().", "Blah");
+			findAllDeadItemsInAllPlaylists();
+			break;
+		default:
+			uBugCheck(); // should never happen unless somebody called us with invalid parameters - bail
+		}
+	}
+};
+
+static mainmenu_commands_factory_t<mainmenu_edit_commands> g_mainmenu_commands_sample_factory;

--- a/foo_bestversion/PlaylistGenerator.cpp
+++ b/foo_bestversion/PlaylistGenerator.cpp
@@ -59,6 +59,28 @@ void replaceTrackInActivePlaylist(const metadb_handle_ptr& trackToReplace, const
 	}
 }
 
+void replaceTrackInAllPlaylists(const metadb_handle_ptr& trackToReplace, const metadb_handle_ptr& replacement)
+{
+	t_size index = 0;
+	static_api_ptr_t<playlist_manager> pm;
+
+	t_size playlist_count = pm->get_playlist_count();
+	for (t_size playlist_index = 0; playlist_index < playlist_count; playlist_index++)
+	{
+		if (pm->playlist_lock_is_present(playlist_index))
+		{
+			continue;
+		}
+		//findDeadItemsInPlaylist(playlist_index, dead_tracks);
+		while (pm->playlist_find_item(playlist_index, trackToReplace, index))
+		{
+			if (!pm->playlist_replace_item(playlist_index, index, replacement)) {
+				break;
+			}
+		}
+	}
+}
+
 //------------------------------------------------------------------------------
 
 } // namespace bestversion

--- a/foo_bestversion/PlaylistGenerator.h
+++ b/foo_bestversion/PlaylistGenerator.h
@@ -7,5 +7,6 @@ namespace bestversion {
 void generatePlaylistFromTracks(const pfc::list_t<metadb_handle_ptr>& tracks);
 void generatePlaylistFromTracks(const pfc::list_t<metadb_handle_ptr>& tracks, const std::string& playlistName);
 void replaceTrackInActivePlaylist(const metadb_handle_ptr& trackToReplace, const metadb_handle_ptr& replacement);
+void replaceTrackInAllPlaylists(const metadb_handle_ptr& trackToReplace, const metadb_handle_ptr& replacement);
 
 } // namespace bestversion

--- a/foo_bestversion/foo_bestversion.vcxproj
+++ b/foo_bestversion/foo_bestversion.vcxproj
@@ -103,6 +103,7 @@
     <ClCompile Include="Component.cpp" />
     <ClCompile Include="ContextMenu.cpp" />
     <ClCompile Include="LastFm.cpp" />
+    <ClCompile Include="MainMenu.cpp" />
     <ClCompile Include="PlaylistGenerator.cpp" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Right now it looks for the same artist/album artist, album, track title and track number in the library and replaces selected item(s) with best bitrate. In short, it is the first commit to address #4. I'm planning also to address #8 and convert both picking best version and replacing with library version of the track to using progress bars. Later:
- Get a list of all dead items in the current playlist/all playlists
- Replace all dead items with best bitrate version from the library
- Replace selected items/all items in all playlists with best bitrate and/or version from the library across all playlists
- Keep a local database like foo_playcount with audio fingerprints for all tracks in media library with an option to calculate fingerprints for tracks outside media library as well for a much more accurate dead item revival as well as best bitrate version lookup option that doesn't depend on precise tags. Will use open source libchromaprint. Preliminary tests show great promise, and it is also used in MusicBrainz's AcoustID which opens new possibilities for tagging.
